### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/animaDenseBMRegistration/animaDenseBMRegistrationPlugin.cpp
+++ b/animaDenseBMRegistration/animaDenseBMRegistrationPlugin.cpp
@@ -60,7 +60,7 @@ QString animaDenseBMRegistrationPlugin::name(void) const
 
 QString animaDenseBMRegistrationPlugin::description(void) const
 {
-    return "ITK implementation of non linear block-matching based registration. \n It is based on papers by Commowick et al.: <a href=\"http://dx.doi.org/10.1007/978-3-642-33418-4_21\">http://dx.doi.org/10.1007/978-3-642-33418-4_21</a>, and Garcia et al.: <a href=\"http://hal.inria.fr/inria-00616148/en\">http://hal.inria.fr/inria-00616148/en</a>.";
+    return "ITK implementation of non linear block-matching based registration. \n It is based on papers by Commowick et al.: <a href=\"https://doi.org/10.1007/978-3-642-33418-4_21\">https://doi.org/10.1007/978-3-642-33418-4_21</a>, and Garcia et al.: <a href=\"http://hal.inria.fr/inria-00616148/en\">http://hal.inria.fr/inria-00616148/en</a>.";
 }
 
 QString animaDenseBMRegistrationPlugin::version(void) const

--- a/animaPyramidalBMRegistration/animaPyramidalBMRegistrationPlugin.cpp
+++ b/animaPyramidalBMRegistration/animaPyramidalBMRegistrationPlugin.cpp
@@ -60,7 +60,7 @@ QString animaPyramidalBMRegistrationPlugin::name(void) const
 
 QString animaPyramidalBMRegistrationPlugin::description(void) const
 {
-    return "This plugin provides an ITK implementation of global linear block-matching registration.\n It is based on papers by Commowick et al.: <a href=\"http://dx.doi.org/10.1109/ISBI.2012.6235644\">http://dx.doi.org/10.1109/ISBI.2012.6235644</a>, and Ourselin et al.: <a href=\"http://dx.doi.org/10.1007/978-3-540-75757-3\">http://dx.doi.org/10.1007/978-3-540-75757-3</a>.";
+    return "This plugin provides an ITK implementation of global linear block-matching registration.\n It is based on papers by Commowick et al.: <a href=\"https://doi.org/10.1109/ISBI.2012.6235644\">https://doi.org/10.1109/ISBI.2012.6235644</a>, and Ourselin et al.: <a href=\"https://doi.org/10.1007/978-3-540-75757-3\">https://doi.org/10.1007/978-3-540-75757-3</a>.";
 }
 
 QString animaPyramidalBMRegistrationPlugin::version(void) const


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). It may be a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old `dx` subdomain is being redirected, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to all static DOI links.

Cheers!